### PR TITLE
fix: minor formatting issues

### DIFF
--- a/gen_errors/csharp.py
+++ b/gen_errors/csharp.py
@@ -20,7 +20,7 @@ class CSharpFormatter:
     """Formatter for C# symbol definitions
        Definitions are formatted as string constants"""
     name = "C#"
-	year = datetime.today().year
+    year = datetime.today().year
 
     msg_file_name = "CouchbaseLiteErrorMessage.cs"
 
@@ -52,9 +52,9 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace Couchbase.Lite
-{
+{{
     internal static partial class CouchbaseLiteErrorMessage
-    {
+    {{
 """.format(year)
 
     def __init__(self, out_dir):

--- a/gen_errors/objc.py
+++ b/gen_errors/objc.py
@@ -20,7 +20,7 @@ from datetime import datetime
 class ObjCFormatter:
     """Formatter for Obj-C symbol definitions"""
     name = "Obj-C"
-	year = datetime.today().year
+    year = datetime.today().year
 
     m_msg_file_name = "CBLMessage.m"
     h_msg_file_name = "CBLMessage.h"


### PR DESCRIPTION
* csharp non field name parenthesis, made double parenthesis. so that the format function won't throw unexpected error.
* indentation by tab is removed and instead used spaces in both csharp and objc.