### PR TITLE
cblite: Added `edit` command

### DIFF
--- a/Xcode/Tools.xcodeproj/project.pbxproj
+++ b/Xcode/Tools.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		272F00D4226F819D00E62F72 /* liblinenoise.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FC8E5A221381890083B033 /* liblinenoise.a */; };
 		272F00D7226F956C00E62F72 /* LogDecoder_stub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 272F00D6226F956C00E62F72 /* LogDecoder_stub.cpp */; };
 		273B206D2640687400A14EC4 /* OpenCommand.cc in Sources */ = {isa = PBXBuildFile; fileRef = 273B206C2640687400A14EC4 /* OpenCommand.cc */; };
+		273B20D4264B2D6900A14EC4 /* EditCommand.cc in Sources */ = {isa = PBXBuildFile; fileRef = 273B20D3264B2D6900A14EC4 /* EditCommand.cc */; };
 		273CE7DF2452067F00D01CA2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273CE7D22452067F00D01CA2 /* SystemConfiguration.framework */; };
 		2751C82E25D3650A00A9B39B /* linenoise.h in Headers */ = {isa = PBXBuildFile; fileRef = 2751C81525D3650A00A9B39B /* linenoise.h */; };
 		2751C83025D3650A00A9B39B /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = 2751C81825D3650A00A9B39B /* utf8.c */; };
@@ -223,6 +224,7 @@
 		272F00D2226F806F00E62F72 /* cbl-log.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "cbl-log.xcconfig"; sourceTree = "<group>"; };
 		272F00D6226F956C00E62F72 /* LogDecoder_stub.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogDecoder_stub.cpp; sourceTree = "<group>"; };
 		273B206C2640687400A14EC4 /* OpenCommand.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OpenCommand.cc; sourceTree = "<group>"; };
+		273B20D3264B2D6900A14EC4 /* EditCommand.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EditCommand.cc; sourceTree = "<group>"; };
 		273CE7D22452067F00D01CA2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		2751C81525D3650A00A9B39B /* linenoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linenoise.h; sourceTree = "<group>"; };
 		2751C81625D3650A00A9B39B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 				2716F94C2491822700BE21D9 /* CheckCommand.cc */,
 				272946AB23FF788400F6B737 /* CompactCommand.cc */,
 				27FC8DD322137C330083B033 /* CpCommand.cc */,
+				273B20D3264B2D6900A14EC4 /* EditCommand.cc */,
 				271BA4AD227CC54300D49D13 /* EncryptCommand.cc */,
 				27FC8DD622137C330083B033 /* InfoCommand.cc */,
 				27F41D5E2329725500EF27BB /* LogcatCommand.cc */,
@@ -799,6 +802,7 @@
 				27175C21261D00200045F3AC /* CdCommand.cc in Sources */,
 				273B206D2640687400A14EC4 /* OpenCommand.cc in Sources */,
 				27FC8DFC22137C580083B033 /* Tool.cc in Sources */,
+				273B20D4264B2D6900A14EC4 /* EditCommand.cc in Sources */,
 				27FC8DE022137C330083B033 /* RevsCommand.cc in Sources */,
 				27175C0F261CE5F40045F3AC /* MkCollCommand.cc in Sources */,
 				27FC8DF522137C490083B033 /* DBEndpoint.cc in Sources */,

--- a/cblite/CBLiteCommand.cc
+++ b/cblite/CBLiteCommand.cc
@@ -19,6 +19,7 @@
 #include "CBLiteCommand.hh"
 
 #ifdef _MSC_VER
+    #include <atlbase.h>
     #include <Shlwapi.h>
     #pragma comment(lib, "shlwapi.lib")
     #undef min
@@ -58,6 +59,20 @@ bool CBLiteCommand::processFlag(const std::string &flag,
     } else {
         return false;
     }
+}
+
+
+string CBLiteCommand::tempDirectory() {
+#ifdef _MSC_VER
+    WCHAR pathBuffer[MAX_PATH + 1];
+    GetTempPathW(MAX_PATH, pathBuffer);
+    GetLongPathNameW(pathBuffer, pathBuffer, MAX_PATH);
+    CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
+    return convertedPath.m_psz;
+#else // _MSC_VER
+    const char *tmp = getenv("TMPDIR");
+    return tmp ? tmp : "/tmp/";
+#endif // _MSC_VER
 }
 
 
@@ -261,27 +276,35 @@ void CBLiteCommand::rawPrint(Value body, slice docID, slice revID) {
 
 
 void CBLiteCommand::prettyPrint(Value value,
-                                   const string &indent,
-                                   slice docID,
-                                   slice revID,
-                                   const set<alloc_slice> *onlyKeys) {
-    // TODO: Support an includeID option
+                                ostream &out,
+                                const string &indent,
+                                slice docID,
+                                slice revID,
+                                const set<alloc_slice> *onlyKeys)
+{
+    string reset, dim, italic;
+    if (&out == &std::cout) {
+        reset = ansiReset();
+        dim = ansiDim();
+        italic = ansiItalic();
+    }
+
     switch (value.type()) {
         case kFLDict: {
             auto dict = value.asDict();
             string subIndent = indent + "  ";
             int n = 0;
-            cout << "{";
+            out << "{";
             if (docID) {
                 n++;
-                cout << '\n' << subIndent << ansiDim() << ansiItalic();
-                cout << (_json5 ? "_id" : "\"_id\"");
-                cout << ansiReset() << ansiDim() << ": \"" << docID << "\"";
+                out << '\n' << subIndent << dim << italic;
+                out << (_json5 ? "_id" : "\"_id\"");
+                out << reset << dim << ": \"" << docID << "\"";
                 if (revID) {
                     n++;
-                    cout << ",\n" << subIndent << ansiItalic();
-                    cout << (_json5 ? "_rev" : "\"_rev\"");
-                    cout << ansiReset() << ansiDim() << ": \"" << revID << "\"";
+                    out << ",\n" << subIndent << italic;
+                    out << (_json5 ? "_rev" : "\"_rev\"");
+                    out << reset << dim << ": \"" << revID << "\"";
                 }
             }
             vector<slice> keys;
@@ -293,30 +316,30 @@ void CBLiteCommand::prettyPrint(Value value,
             sort(keys.begin(), keys.end());
             for (slice key : keys) {
                 if (n++ > 0)
-                    cout << ',' << ansiReset();
-                cout << '\n' << subIndent << ansiItalic();
+                    out << ',' << reset;
+                out << '\n' << subIndent << italic;
                 if (_json5 && canBeUnquotedJSON5Key(key))
-                    cout << key;
+                    out << key;
                 else
-                    cout << '"' << key << '"';      //FIX: Escape quotes
-                cout << ansiReset() << ": ";
+                    out << '"' << key << '"';      //FIX: Escape quotes
+                out << reset << ": ";
 
-                prettyPrint(dict.get(key), subIndent);
+                prettyPrint(dict.get(key), out, subIndent);
             }
-            cout << '\n' << indent << "}";
+            out << '\n' << indent << "}";
             break;
         }
         case kFLArray: {
             string subIndent = indent + "  ";
-            cout << "[\n";
+            out << "[\n";
             for (Array::iterator i(value.asArray()); i; ++i) {
-                cout << subIndent;
-                prettyPrint(i.value(), subIndent);
+                out << subIndent;
+                prettyPrint(i.value(), out, subIndent);
                 if (i.count() > 1)
-                    cout << ',';
-                cout << '\n';
+                    out << ',';
+                out << '\n';
             }
-            cout << indent << "]";
+            out << indent << "]";
             break;
         }
         case kFLData: {
@@ -324,29 +347,29 @@ void CBLiteCommand::prettyPrint(Value value,
             static const char kHexDigits[17] = "0123456789abcdef";
             slice data = value.asData();
             auto end = (const uint8_t*)data.end();
-            cout << "«";
-            bool dim = false;
+            out << "«";
+            bool dimmed = false;
             for (auto c = (const uint8_t*)data.buf; c != end; ++c) {
                 if (*c >= 32 && *c < 127) {
-                    if (dim)
-                        cout << ansiReset();
-                    dim = false;
-                    cout << (char)*c;
+                    if (dimmed)
+                        out << reset;
+                    dimmed = false;
+                    out << (char)*c;
                 } else {
-                    if (!dim)
-                        cout << ansiDim();
-                    dim = true;
-                    cout << '\\' << kHexDigits[*c/16] << kHexDigits[*c%16];
+                    if (!dimmed)
+                        out << dim;
+                    dimmed = true;
+                    out << '\\' << kHexDigits[*c/16] << kHexDigits[*c%16];
                 }
             }
-            if (dim)
-                cout << ansiReset();
-            cout << "»";
+            if (dimmed)
+                out << reset;
+            out << "»";
             break;
         }
         default: {
             alloc_slice json(value.toJSON());
-            cout << json;
+            out << json;
             break;
         }
     }

--- a/cblite/CBLiteCommand.cc
+++ b/cblite/CBLiteCommand.cc
@@ -150,12 +150,8 @@ c4::ref<C4Document> CBLiteCommand::readDoc(string docID, C4DocContentLevel conte
 #else
     c4::ref<C4Document> doc = c4db_getDoc(_db, slice(docID), true, content, &error);
 #endif
-    if (!doc) {
-        if (error.domain == LiteCoreDomain && error.code == kC4ErrorNotFound)
-            cerr << "Error: Document \"" << docID << "\" not found.\n";
-        else
-            errorOccurred(format("reading document \"%s\"", docID.c_str()), error);
-    }
+    if (!doc && (error.domain != LiteCoreDomain || error.code != kC4ErrorNotFound))
+        errorOccurred(format("reading document \"%s\"", docID.c_str()), error);
     return doc;
 }
 

--- a/cblite/CBLiteCommand.hh
+++ b/cblite/CBLiteCommand.hh
@@ -7,6 +7,7 @@
 #pragma once
 #include "CBLiteTool.hh"
 #include <functional>
+#include <string>
 
 /** Abstract base class of the 'cblite' tool's subcommands. */
 class CBLiteCommand : public CBLiteTool {
@@ -44,6 +45,8 @@ public:
     virtual bool processFlag(const std::string &flag,
                              const std::initializer_list<FlagSpec> &specs) override;
 
+    std::string tempDirectory();
+
 protected:
     void writeUsageCommand(const char *cmd, bool hasFlags, const char *otherArgs ="");
 
@@ -54,6 +57,7 @@ protected:
 
     void rawPrint(fleece::Value body, fleece::slice docID, fleece::slice revID =fleece::nullslice);
     void prettyPrint(fleece::Value value,
+                     std::ostream &out,
                      const std::string &indent ="",
                      fleece::slice docID =fleece::nullslice,
                      fleece::slice revID =fleece::nullslice,
@@ -123,6 +127,7 @@ CBLiteCommand* newCatCommand(CBLiteTool&);
 CBLiteCommand* newCheckCommand(CBLiteTool&);
 CBLiteCommand* newCompactCommand(CBLiteTool&);
 CBLiteCommand* newCpCommand(CBLiteTool&);
+CBLiteCommand* newEditCommand(CBLiteTool&);
 CBLiteCommand* newExportCommand(CBLiteTool&);
 CBLiteCommand* newImportCommand(CBLiteTool&);
 CBLiteCommand* newInfoCommand(CBLiteTool&);

--- a/cblite/CBLiteCommand.hh
+++ b/cblite/CBLiteCommand.hh
@@ -53,6 +53,7 @@ protected:
     void openDatabaseFromNextArg();
     void openWriteableDatabaseFromNextArg();
 
+    /// Loads a document. Returns null if not found; fails on any other error.
     c4::ref<C4Document> readDoc(std::string docID, C4DocContentLevel);
 
     void rawPrint(fleece::Value body, fleece::slice docID, fleece::slice revID =fleece::nullslice);

--- a/cblite/CBLiteTool.cc
+++ b/cblite/CBLiteTool.cc
@@ -275,6 +275,7 @@ static constexpr struct {const char* name; ToolFactory factory;} kSubcommands[] 
     {"check",   newCheckCommand},
     {"compact", newCompactCommand},
     {"cp",      newCpCommand},
+    {"edit",    newEditCommand},
     {"export",  newExportCommand},
     {"file",    newInfoCommand},
     {"import",  newImportCommand},

--- a/cblite/CBLiteTool.cc
+++ b/cblite/CBLiteTool.cc
@@ -63,6 +63,7 @@ void CBLiteTool::usage() {
     "    cat            : display document body(ies) as JSON\n"
     "    check          : check for database corruption\n"
     "    compact        : free up unused space\n"
+    "    edit           : update or create a document as JSON in a text editor\n"
 #ifdef COUCHBASE_ENTERPRISE
     "    encrypt,decrypt: add or remove encryption\n"
 #endif

--- a/cblite/CatCommand.cc
+++ b/cblite/CatCommand.cc
@@ -71,6 +71,8 @@ public:
                 if (doc) {
                     catDoc(doc, includeIDs);
                     cout << '\n';
+                } else {
+                    cerr << "Error: Document \"" << docID << "\" not found.\n";
                 }
             }
         }

--- a/cblite/CpCommand.cc
+++ b/cblite/CpCommand.cc
@@ -150,7 +150,7 @@ public:
     void createTemporaryDB(slice dbName) {
         if (_db)
             fail("A database is already open");
-        _tempDir = FilePath(string(getenv("TMPDIR")), "").mkTempDir();
+        _tempDir = FilePath(tempDirectory(), "").mkTempDir();
         string path = _tempDir->path();
         _dbFlags = kC4DB_Create;
         C4DatabaseConfig2 config = {slice(path), _dbFlags};

--- a/cblite/EditCommand.cc
+++ b/cblite/EditCommand.cc
@@ -1,0 +1,187 @@
+//
+// EditCommand.cc
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "CBLiteCommand.hh"
+#include "fleece/Fleece.hh"
+#include "FilePath.hh"
+#include "sliceIO.hh"
+#include <algorithm>
+#include <set>
+
+#ifndef _MSC_VER
+    #include <unistd.h>
+    // Weirdly, this variable is defined by POSIX but doesn't appear in a system header(?)
+    extern char** environ;
+#endif
+
+using namespace std;
+using namespace fleece;
+using namespace litecore;
+
+
+class EditCommand : public CBLiteCommand {
+public:
+    EditCommand(CBLiteTool &parent)
+    :CBLiteCommand(parent)
+    { }
+
+
+    void usage() override {
+        writeUsageCommand("edit", true, "DOCID");
+        cerr <<
+        "  Update a document by editing it in your favorite $EDITOR.\n"
+        "    --raw : Raw JSON (not pretty-printed)\n"
+        "    --json5 : JSON5 syntax (no quotes around dict keys)\n"
+        "    -- : End of arguments (use if DOCID starts with '-')\n"
+        ;
+    }
+
+
+    void runSubcommand() override {
+        // Read params:
+        processFlags({
+            {"--raw",    [&]{_prettyPrint = false;}},
+            {"--json5",  [&]{_json5 = true;}},
+        });
+        openWriteableDatabaseFromNextArg();
+        string docID = nextArg("document ID");
+        unquoteGlobPattern(docID); // remove any protective backslashes
+        endOfArgs();
+
+        // Read the doc:
+        c4::ref<C4Document> doc = readDoc(docID, kDocGetCurrentRev);
+        if (!doc)
+            return;
+        // Convert to JSON:
+        string json;
+        if (_prettyPrint) {
+            stringstream out;
+            out << "// You are editing document \"" << docID
+                        << "\" of database \"" << slice(c4db_getName(_db)) << "\".\n"
+                   "// Any changes you make will be saved back to the database when you exit.\n"
+                   "// To abort, exit the editor without saving changes.\n\n";
+            prettyPrint(Dict(c4doc_getProperties(doc)), out);
+            json = out.str();
+        } else {
+            auto raw = alloc_slice(c4doc_bodyAsJSON(doc, true, nullptr));
+            json = string(raw) + "\n";
+        }
+
+        while (true) {
+            // Write the JSON to a temp file:
+            FILE *fd = nullptr;
+            FilePath tmpFile = FilePath(tempDirectory(), "").mkTempFile(&fd);
+            string tmpFilePath = tmpFile.path();
+            bool ok = (fputs(json.c_str(), fd) >= 0);
+            fclose(fd);
+            if (!ok)
+                fail("Couldn't write to temporary file");
+
+            // Run the editor and wait for it to finish:
+            const char *editor = getenv("EDITOR");
+            if (!editor)
+                fail("$EDITOR environment variable is not set");
+            invokeEditor(editor, tmpFilePath.c_str());
+
+            // Reread the file:
+            alloc_slice newJSON = fleece::readFile(tmpFilePath.c_str());
+            tmpFile.del();
+            if (newJSON == slice(json)) {
+                cout << "(No changes made in editor)\n";
+                return;
+            }
+
+            C4Error error;
+            c4::Transaction t(_db);
+            if (!t.begin(&error))
+                fail("starting a transaction", error);
+
+            // Parse the edited body as JSON5:
+            alloc_slice newBody;
+            FLStringResult msg;
+            auto cvtd = alloc_slice(FLJSON5_ToJSON(newJSON, &msg, nullptr, nullptr));
+            if (cvtd) {
+                newBody = alloc_slice(c4db_encodeJSON(_db, cvtd, &error));
+                if (!newBody)
+                    msg = c4error_getMessage(error);
+            }
+            if (!newBody) {
+                cout << "Sorry, that isn't valid JSON. Want to correct it [y/n]?";
+                FLSliceResult_Release(msg);
+                char input[100];
+                if (!fgets(input, 100, stdin) || tolower(input[0]) == 'n')
+                    return;
+                json = string(newJSON);
+                continue; // try again...
+            }
+
+            // Finally, update the document:
+            c4::ref<C4Document> newDoc = c4doc_update(doc, newBody, doc->selectedRev.flags, &error);
+            if (!newDoc || !t.commit(&error))
+                fail("updating document", error);
+            cout << "Updated \"" << docID << "\".\n";
+            break;
+        }
+    }
+
+
+#ifdef _MSC_VER
+    void invokeEditor(const char *editor, const char *fileToEdit) {
+        fail("Invoking editor is unimplemented on Windows");
+    }
+#else
+    void invokeEditor(const char *editor, const char *fileToEdit) {
+        // In Unix, running a new process involves forking and calling `execve` in the child:
+        pid_t pid = fork();
+        if (pid < 0) {
+            // Fork failed:
+            fail("Couldn't start editor " + string(editor));
+        } else if (pid == 0) {
+            // I am the child process -- exec the editor:
+            char* const argv[3] = {(char*)editor, (char*)fileToEdit, nullptr};
+            execve(editor, argv, environ);
+            // If execve returned it failed, but as we've forked there's nothing we can do
+            ::exit(1);
+        }
+
+        // In the original process, wait for the forked process to exit...
+        int status;
+        if (waitpid(pid, &status, 0) < 0)
+            fail(format("Error waiting for the editor to finish (errno=%d)", errno));
+        else if (!WIFEXITED(status))
+            fail(format("Editor %s crashed (signal %d)",
+                        editor, WTERMSIG(status)));
+        else if (WEXITSTATUS(status) != 0)
+            fail(format("Editor %s exited abnormally (status %d)",
+                        editor, WEXITSTATUS(status)));
+    }
+#endif
+
+
+    void addLineCompletions(ArgumentTokenizer &tokenizer,
+                            function<void(const string&)> add) override
+    {
+        addDocIDCompletions(tokenizer, add);
+    }
+
+}; // end editCommand
+
+
+CBLiteCommand* newEditCommand(CBLiteTool &parent) {
+    return new EditCommand(parent);
+}

--- a/cblite/ListCommand.cc
+++ b/cblite/ListCommand.cc
@@ -153,7 +153,7 @@ void ListCommand::catDoc(C4Document *doc, bool includeID) {
     if (_showRevID)
         revID = (slice)doc->selectedRev.revID;
     if (_prettyPrint)
-        prettyPrint(body, "", docID, revID, (_keys.empty() ? nullptr : &_keys));
+        prettyPrint(body, cout, "", docID, revID, (_keys.empty() ? nullptr : &_keys));
     else
         rawPrint(body, docID, revID);
 }

--- a/cblite/RevsCommand.cc
+++ b/cblite/RevsCommand.cc
@@ -57,7 +57,7 @@ public:
 
         _doc = readDoc(docID, kDocGetAll);
         if (!_doc)
-            return;
+            fail("Document not found");
 
         bool versionVectors = (c4db_getConfig2(_db)->flags & kC4DB_VersionVectors) != 0;
         if (versionVectors)

--- a/cblite/SQLCommand.cc
+++ b/cblite/SQLCommand.cc
@@ -50,7 +50,7 @@ public:
         if (!fleeceResult)
             fail("Query failed", error);
 
-        prettyPrint(Value::fromData(fleeceResult));
+        prettyPrint(Value::fromData(fleeceResult), cout);
         cout << '\n';
     }
 


### PR DESCRIPTION
```
cblite edit [FLAGS] DBPATH DOCID
  Update a document by editing it in your favorite $EDITOR.
    --raw : Raw JSON (not pretty-printed)
    --json5 : JSON5 syntax (no quotes around dict keys)
    -- : End of arguments (use if DOCID starts with '-')
```
Not supported on Windows yet due to lack of `fork` syscall