### PR TITLE
Add missing include <climits>

### DIFF
--- a/gen_defaults/c.py
+++ b/gen_defaults/c.py
@@ -69,6 +69,7 @@ CBL_CAPI_END
 
 top_level_format_impl = license + """
 #include "CBLDefaults.h"
+#include <climits>
 
 {generated}
 """


### PR DESCRIPTION
The include is required for UINT_MAX.