### PR TITLE
Disable SelfSignedCertificateOnly default value for C

### DIFF
--- a/gen_defaults/cbl-defaults.json
+++ b/gen_defaults/cbl-defaults.json
@@ -153,7 +153,8 @@
                     "id": "boolean",
                     "subset": "system"
                 },
-                "description": "Whether or not a replicator only accepts self-signed certificates from the remote"
+                "description": "Whether or not a replicator only accepts self-signed certificates from the remote",
+                "only_on": ["objc", "swift", "java"]
             },
             {
                 "name": "AcceptParentCookies",


### PR DESCRIPTION
The SelfSignedCertificateOnly is not applicable for C as C doesn’t support peer-to-peer.