### PR TITLE
CBL-4202 : Add User-Agent to replicator params

### DIFF
--- a/litecp/DBEndpoint.cc
+++ b/litecp/DBEndpoint.cc
@@ -379,6 +379,14 @@ C4ReplicatorParameters DbEndpoint::replicatorParameters(C4ReplicatorMode push, C
             enc.writeKey(slice(kC4ReplicatorOptionRootCerts));
             enc.writeData(_rootCerts);
         }
+        // User-Agent (Required by AWS Capella: CBL-4202)
+        enc.writeKey(slice(kC4ReplicatorOptionExtraHeaders));
+        enc.beginDict();
+        enc.writeKey(slice("User-Agent"));
+        alloc_slice version = c4_getVersion();
+        enc.writeString(format("cblite/%.*s", SPLAT(version)));
+        enc.endDict();
+        
         enc.endDict();
         _options = enc.finish();
         params.optionsDictFleece = _options;


### PR DESCRIPTION
* Added User-Agent to the replicator params for the replicator used by cblite tool. 
* Example : `User-Agent: cblite/0.0.0 (b019a12d)`
* Note : The User-Agent is required by the AWS Capella.
* Update LiteCore to 3.0.10-2.