### PR TITLE
CBL-4204 : Add User-Agent to replicator params

### DIFF
--- a/litecp/DBEndpoint.cc
+++ b/litecp/DBEndpoint.cc
@@ -411,6 +411,14 @@ C4ReplicatorParameters DbEndpoint::replicatorParameters(C4ReplicatorMode push, C
             enc.writeKey(slice(kC4ReplicatorOptionRootCerts));
             enc.writeData(_rootCerts);
         }
+        
+        // User-Agent (Required by AWS Capella: CBL-4204)
+        enc.writeKey(slice(kC4ReplicatorOptionExtraHeaders));
+        enc.beginDict();
+        enc.writeKey(slice("User-Agent"));
+        alloc_slice version = c4_getVersion();
+        enc.writeString(format("cblite/%.*s", SPLAT(version)));
+        enc.endDict();
 
         enc.endDict();
         _options = enc.finish();


### PR DESCRIPTION
* Added User-Agent to the replicator params for the replicator used by cblite tool. 
* The User-Agent is required by the AWS Capella.
* Manually ported the fix from the lithium branch : 8434d06aaffd4dc5b2667d2a0a535266c3d941f1